### PR TITLE
Reversed order of module.exports and define.amd check

### DIFF
--- a/mt-latlon.js
+++ b/mt-latlon.js
@@ -426,10 +426,10 @@
   };
 
   // Add support for AMD, Node and plain JS
-  if (typeof define === 'function' && define.amd) {
-      define(wrapper);
-  } else if (typeof exports === 'object') {
+  if (typeof exports === 'object') {
       module.exports = wrapper;
+  } else if (typeof define === 'function' && define.amd) {
+      define(wrapper);
   } else {
       root.LatLon = wrapper(Geo);
   }


### PR DESCRIPTION
## Webpack Support

Best to check for module.exports first to be compatible with webpack builds
